### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,13 @@ jobs:
 
     name: Foundry project
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
+          persist-credentials: false
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0


### PR DESCRIPTION
## Summary

Fixed the following zizmor security findings in workflow files:

- **artipacked** (`.github/workflows/test.yml`): Added `persist-credentials: false` to `actions/checkout` step to prevent credential persistence through GitHub Actions artifacts.
- **excessive-permissions** (`.github/workflows/test.yml`): Added `permissions: contents: read` block to the `check` job to narrow default permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)